### PR TITLE
Fix error 404 on lesson-1 for Ecotone Lite version

### DIFF
--- a/tutorial-php-ddd-cqrs-event-sourcing/php-messaging-architecture.md
+++ b/tutorial-php-ddd-cqrs-event-sourcing/php-messaging-architecture.md
@@ -109,13 +109,15 @@ Go to "app/EcotoneQuickstart.php"
 {% endtab %}
 
 {% tab title="Lite" %}
+{% code title="https://github.com/ecotoneframework/quickstart-lite/blob/lesson-1/src/EcotoneQuickstart.php" %}
 ```php
-https://github.com/ecotoneframework/quickstart-lite/blob/lesson-1/src/EcotoneQuickstart.php
+
 
 Go to "src/EcotoneQuickstart.php"
 
 # This class is autoregistered using PHP-DI
 ```
+{% endcode %}
 {% endtab %}
 {% endtabs %}
 


### PR DESCRIPTION
Even if GH redirection work fine between old URL (in doc) and new target (for SF/Laravel/and Ecotone Lite),
 https://github.com/ecotoneframework/lite-tutorial/blob/lesson-1/src/EcotoneQuickstart.php, there are some wrong closed code/tabs in tutorial lesson 1 documentation.
